### PR TITLE
Set settings for using in chromium apps

### DIFF
--- a/Mon2Cam.sh
+++ b/Mon2Cam.sh
@@ -82,7 +82,7 @@ then
 	fi
 
 	# Load v4lwloopback module
-	sudo modprobe v4l2loopback video_nr="$DEVICE_NUMBER" 'card_label=Mon2Cam'
+	sudo modprobe v4l2loopback video_nr="$DEVICE_NUMBER" exclusive_caps=1 'card_label=Mon2Cam'
 fi
 
 # Option checking


### PR DESCRIPTION
In order to use this in Chrome, or other apps that build on chromium (such as the Slack-App apparently) an additional setting is neede when creating the device for it to appear in the browser.

See https://github.com/umlaeute/v4l2loopback/issues/78#issuecomment-70320902 and https://bugs.chromium.org/p/chromium/issues/detail?id=757399